### PR TITLE
Fix timer

### DIFF
--- a/Controller/RacetimeChannel.cs
+++ b/Controller/RacetimeChannel.cs
@@ -342,7 +342,6 @@ start:
                     //the race is starting
                     if ((r == RaceState.Open || r == RaceState.OpenInviteOnly) && nr == RaceState.Starting)
                     {
-                        m.Reset();
                         m.Start();
                     }
 

--- a/Controller/RacetimeChannel.cs
+++ b/Controller/RacetimeChannel.cs
@@ -343,7 +343,7 @@ start:
                     if ((r == RaceState.Open || r == RaceState.OpenInviteOnly) && nr == RaceState.Starting)
                     {
                         m.Reset();
-                        m.Start(DateTime.UtcNow - msg.Race.StartedAt);
+                        m.Start();
                     }
 
                     //the race is already running and we're not finished, sync the timer
@@ -354,7 +354,7 @@ start:
                         if (m.CurrentState.CurrentPhase == TimerPhase.Paused)
                             m.Pause();
                         if (m.CurrentState.CurrentPhase == TimerPhase.NotRunning)
-                            m.Start(DateTime.UtcNow - msg.Race.StartedAt);
+                            m.Start();
                     }
                 }                      
             }

--- a/Controller/RacetimeChannel.cs
+++ b/Controller/RacetimeChannel.cs
@@ -342,41 +342,20 @@ start:
                     //the race is starting
                     if ((r == RaceState.Open || r == RaceState.OpenInviteOnly) && nr == RaceState.Starting)
                     {
-                        m.CurrentState.Run.Offset = DateTime.UtcNow - msg.Race.StartedAt;
                         m.Reset();
-                        m.Start();
+                        m.Start(DateTime.UtcNow - msg.Race.StartedAt);
                     }
 
                     //the race is already running and we're not finished, sync the timer
                     if(nr == RaceState.Started && nu == UserStatus.Racing)
                     {
-                        m.CurrentState.Run.Offset = DateTime.UtcNow - msg.Race.StartedAt;
                         if (m.CurrentState.CurrentPhase == TimerPhase.Ended)
                             m.UndoSplit();
                         if (m.CurrentState.CurrentPhase == TimerPhase.Paused)
                             m.Pause();
                         if (m.CurrentState.CurrentPhase == TimerPhase.NotRunning)
-                            m.Start();
+                            m.Start(DateTime.UtcNow - msg.Race.StartedAt);
                     }
-
-                    if(u != nu && nu == UserStatus.Finished)
-                    {
-                        m.Split();
-                    }
-
-                    if (u != nu && nu == UserStatus.Forfeit)
-                    {
-                        m.Reset();
-                    }
-                    if (u != nu && nu == UserStatus.Disqualified)
-                    {
-                        m.Reset();
-                    }
-
-                    if (r != nr && nr == RaceState.Cancelled)
-                    {
-                        m.Reset();
-                    }                    
                 }                      
             }
 


### PR DESCRIPTION
Updates the channel component to work with the timer in a more sensible way.

* The plugin will no longer adjust the timer offset in the user's splits data.
* ~~The timer offset is now supplied directly to the timer Start() method (using https://github.com/LiveSplit/LiveSplit/pull/1856).~~
* Remove automatic split/reset based on user's completion status when connecting to a room (this causes more problems than it solves I think).