### PR TITLE
Auto Updater fix

### DIFF
--- a/LiveSplit.Racetime.csproj
+++ b/LiveSplit.Racetime.csproj
@@ -57,6 +57,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -148,6 +149,8 @@ del cef_extensions.pak
 del devtools_resources.pak
 del d3dcompiler_47.dll
 del libEGL.dll
-del libGLESv2.dll</PostBuildEvent>
+del libGLESv2.dll
+PowerShell.exe Invoke-Command -ScriptBlock { Compress-Archive -Path libcef.dll -DestinationPath libcef.zip }
+del libcef.dll</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/RacetimeAPI.cs
+++ b/RacetimeAPI.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace LiveSplit.Racetime
 {
@@ -40,7 +41,25 @@ namespace LiveSplit.Racetime
 
         public void Join(ITimerModel model, string id)
         {
-
+            if (File.Exists(AppDomain.CurrentDomain.BaseDirectory + "Components/libcef.zip"))
+            {
+                System.IO.Compression.ZipFile.ExtractToDirectory(AppDomain.CurrentDomain.BaseDirectory + "Components/libcef.zip", AppDomain.CurrentDomain.BaseDirectory + "Components/");
+                if (File.Exists(AppDomain.CurrentDomain.BaseDirectory + "Components/libcef.dll"))
+                {
+                    File.Delete(Path.Combine(AppDomain.CurrentDomain.BaseDirectory + "Components/", "libcef.zip"));
+                }
+                MessageBox.Show("LiveSplit must restart to use Racetime.gg", "Must Restart", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                try
+                {
+                    Application.Restart();
+                }
+                catch { }
+                try
+                {
+                    System.Environment.Exit(0);
+                }
+                catch { }
+            }
             var channel = new RacetimeChannel(model.CurrentState, model, (RacetimeSettings)Settings);
             var form = new ChannelForm(channel, id, model.CurrentState.LayoutSettings.AlwaysOnTop);
         }

--- a/RacetimeAPI.cs
+++ b/RacetimeAPI.cs
@@ -1,4 +1,6 @@
-﻿using LiveSplit.Model;
+﻿using CefSharp;
+using CefSharp.WinForms;
+using LiveSplit.Model;
 using LiveSplit.Racetime.Controller;
 using LiveSplit.Racetime.Model;
 using LiveSplit.Racetime.View;
@@ -43,7 +45,11 @@ namespace LiveSplit.Racetime
         {
             if (File.Exists(AppDomain.CurrentDomain.BaseDirectory + "Components/libcef.zip"))
             {
-                System.IO.Compression.ZipFile.ExtractToDirectory(AppDomain.CurrentDomain.BaseDirectory + "Components/libcef.zip", AppDomain.CurrentDomain.BaseDirectory + "Components/");
+                try
+                {
+                    System.IO.Compression.ZipFile.ExtractToDirectory(AppDomain.CurrentDomain.BaseDirectory + "Components/libcef.zip", AppDomain.CurrentDomain.BaseDirectory + "Components/");
+                }
+                catch { }
                 if (File.Exists(AppDomain.CurrentDomain.BaseDirectory + "Components/libcef.dll"))
                 {
                     File.Delete(Path.Combine(AppDomain.CurrentDomain.BaseDirectory + "Components/", "libcef.zip"));
@@ -61,7 +67,7 @@ namespace LiveSplit.Racetime
                 catch { }
             }
             var channel = new RacetimeChannel(model.CurrentState, model, (RacetimeSettings)Settings);
-            var form = new ChannelForm(channel, id, model.CurrentState.LayoutSettings.AlwaysOnTop);
+            _ = new ChannelForm(channel, id, model.CurrentState.LayoutSettings.AlwaysOnTop);
         }
 
         public void Warn()
@@ -116,16 +122,8 @@ namespace LiveSplit.Racetime
                 foreach (var r in races)
                 {
                     Race raceObj;
-                    //if (Races == null)
-                    //{
                     r.entrants = new List<dynamic>();
                     raceObj = RTModelBase.Create<Race>(r);
-                    //}
-                    //else
-                    //{
-                    //    var fulldata = JSON.FromUri(new Uri(BaseUri.AbsoluteUri + r.name + "/data"));
-                    //    raceObj = RTModelBase.Create<Race>(fulldata);
-                    //}
                     yield return raceObj;
                 }
                 yield break;

--- a/RacetimeFactory.cs
+++ b/RacetimeFactory.cs
@@ -32,6 +32,6 @@ namespace LiveSplit.Racetime
 
         public string UpdateURL => "http://livesplit.org/update/";
 
-        public Version Version => Version.Parse("1.8.16");
+        public Version Version => Version.Parse("1.8.19");
     }
 }


### PR DESCRIPTION
This PR will do the following

**LibCef Compression for smaller distros (Should allow for distribution via the updater again)**
 - Compress libcef.dll to libcef.zip on build
 -  Remove the original libcef.dll for sizing in the zip
 - It will then on load unzip libcef.zip if it exists and prompt a user to restart their app (only if they tried to log into a racetime.gg race)
 - From there on it will use the unzipped libcef file to render the website.


**Crash Fixes**
- Attempt to check if the handle for the chatbox has been created before trying to invoke livesplit data
- Check if the authentication response from racetime was a success before trying to pass an authorization token
- General catch for Cef init failures