### PR TITLE
Add support for racetime.gg race comparisons

### DIFF
--- a/Controller/RacetimeChannel.cs
+++ b/Controller/RacetimeChannel.cs
@@ -45,6 +45,7 @@ namespace LiveSplit.Racetime.Controller
         public RacetimeSettings Settings { get; set; }
         public string OpenedBy { get; set; }
         public string Username { get; set; }
+        public string UserID { get; set; }
         public bool Invited = false;
         public TimeSpan Offset { get; set; }
         public RacetimeAuthenticator Token { get; set; }
@@ -181,6 +182,7 @@ namespace LiveSplit.Racetime.Controller
 
                 AuthResult r = await Authenticator.Authorize();
                 Username = Authenticator.Identity?.Name;
+                UserID = Authenticator.Identity?.ID;
                 switch (r)
                 {
                     case AuthResult.Success:
@@ -400,12 +402,20 @@ namespace LiveSplit.Racetime.Controller
         private void UpdateSplitComparison(SplitMessage msg)
         {
             SplitUpdate split = msg.SplitUpdate;
-            if (split.UserName == Username)
+            if (split.UserID == UserID)
             {
                 return;
             }
+
             var run = Model.CurrentState.Run;
-            var comparisonName = RacetimeComparisonGenerator.GetRaceComparisonName(split.UserName);
+
+            var user = Race?.Entrants?.FirstOrDefault(x => x.ID == split.UserID);
+            if (user == null)
+            {
+                return;
+            }
+
+            var comparisonName = RacetimeComparisonGenerator.GetRaceComparisonName(user.FullName);
             var segment = run.FirstOrDefault(x => x.Name.Trim().ToLower() == split.SplitName && x.Comparisons[comparisonName][TimingMethod.RealTime] == null);
 
             if (split.IsUndo)

--- a/LiveSplit.Racetime.csproj
+++ b/LiveSplit.Racetime.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Controller\RacetimeAuthenticator.cs" />
     <Compile Include="Controller\RTAuthentificationSettings.cs" />
     <Compile Include="Model\RTModelBase.cs" />
+    <Compile Include="Model\SplitUpdate.cs" />
     <Compile Include="RacetimeAPI.cs" />
     <Compile Include="Model\MessageType.cs" />
     <Compile Include="Model\ChatMessage.cs" />
@@ -85,6 +86,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="RacetimeComparisonGenerator.cs" />
     <Compile Include="RacetimeFactory.cs" />
     <Compile Include="RacetimeSettings.cs" />
     <Compile Include="RacetimeSettingsControl.cs">

--- a/Model/ChatMessage.cs
+++ b/Model/ChatMessage.cs
@@ -17,7 +17,7 @@ namespace LiveSplit.Racetime.Model
             get
             {
                 try
-                {                    
+                {
                     return Data.message;
                 }
                 catch
@@ -68,7 +68,7 @@ namespace LiveSplit.Racetime.Model
                 {
                     return false;
                 }
-               
+
             }
         }
         public bool IsSystem
@@ -83,11 +83,11 @@ namespace LiveSplit.Racetime.Model
                 {
                     return false;
                 }
-                
+
             }
         }
-        
-        
+
+
 
     }
 
@@ -111,7 +111,7 @@ namespace LiveSplit.Racetime.Model
                 user = RacetimeUser.LiveSplit,
                 posted_at = DateTime.Now.ToString(),
                 highlight = important,
-                is_system = true                   
+                is_system = true
             };
             return Create<LiveSplitMessage>(dataroot);
         }
@@ -243,13 +243,39 @@ namespace LiveSplit.Racetime.Model
                     return "Error in the error message";
                 }
             }
-                
+
+        }
+    }
+    public class SplitMessage : ChatMessage
+    {
+        public override MessageType Type => MessageType.SplitUpdate;
+        public override string Message
+        {
+            get
+            {
+                try
+                {
+                    return Data.message_plain;
+                }
+                catch
+                {
+                    return Data.message;
+                }
+            }
+        }
+
+        public SplitUpdate SplitUpdate
+        {
+            get
+            {
+                return RTModelBase.Create<SplitUpdate>(Data);
+            }
         }
     }
     public class RaceMessage : ChatMessage
     {
         public override MessageType Type => MessageType.Race;
-        
+
         public override string Message
         {
             get

--- a/Model/MessageType.cs
+++ b/Model/MessageType.cs
@@ -14,6 +14,7 @@ namespace LiveSplit.Racetime.Model
         Race,
         System,
         LiveSplit,
+        SplitUpdate,
         Bot
     }
 }

--- a/Model/RacetimeUser.cs
+++ b/Model/RacetimeUser.cs
@@ -23,6 +23,20 @@ namespace LiveSplit.Racetime.Model
         {
             return Name.ToLower() == ((RacetimeUser)obj)?.Name?.ToLower();
         }
+        public string ID
+        {
+            get
+            {
+                return Data.id;
+            }
+        }
+        public string FullName
+        {
+            get
+            {
+                return Data.full_name;
+            }
+        }
         public string Name
         {
             get
@@ -64,7 +78,7 @@ namespace LiveSplit.Racetime.Model
                         case "bot": r |= UserRole.Bot; break;
                         case "system": r |= UserRole.System; break;
                         case "anonymous": r |= UserRole.Anonymous; break;
-                    } 
+                    }
                 }
                 return r;
             }
@@ -195,7 +209,7 @@ namespace LiveSplit.Racetime.Model
         public static RacetimeUser LiveSplit = CreateBot("LiveSplit", "system staff moderator monitor");
         public static RacetimeUser Anonymous = CreateBot("Anonymous", "anonymous");
 
-        
+
         public static RacetimeUser CreateBot(string botname, string flairs)
         {
             var dataroot = new

--- a/Model/SplitUpdate.cs
+++ b/Model/SplitUpdate.cs
@@ -39,11 +39,11 @@ namespace LiveSplit.Racetime.Model
             }
         }
 
-        public string UserName
+        public string UserID
         {
             get
             {
-                return Data.username;
+                return Data.user_id;
             }
         }
     }

--- a/Model/SplitUpdate.cs
+++ b/Model/SplitUpdate.cs
@@ -1,0 +1,50 @@
+using System;
+using LiveSplit.Model;
+
+namespace LiveSplit.Racetime.Model
+{
+    public class SplitUpdate : RTModelBase
+    {
+        public string SplitName
+        {
+            get
+            {
+                return Data.split_name;
+            }
+        }
+
+        public TimeSpan? SplitTime
+        {
+            get
+            {
+                if (Data.split_time == "-")
+                    return null;
+                return TimeSpanParser.Parse(Data.split_time);
+            }
+        }
+
+        public bool IsUndo
+        {
+            get
+            {
+                return Data.is_undo;
+            }
+        }
+
+        public bool IsFinish
+        {
+            get
+            {
+                return Data.is_finish;
+            }
+        }
+
+        public string UserName
+        {
+            get
+            {
+                return Data.username;
+            }
+        }
+    }
+}

--- a/RacetimeComparisonGenerator.cs
+++ b/RacetimeComparisonGenerator.cs
@@ -1,0 +1,31 @@
+using LiveSplit.Model;
+using LiveSplit.Model.Comparisons;
+using LiveSplit.Options;
+
+namespace LiveSplit.Racetime
+{
+    class RacetimeComparisonGenerator : IComparisonGenerator
+    {
+        public IRun Run { get; set; }
+        public string Name { get; protected set; }
+
+        public RacetimeComparisonGenerator(string name)
+        {
+            Name = name;
+        }
+
+        public void Generate(ISettings settings)
+        {
+        }
+
+        public static string GetRaceComparisonName(string user)
+        {
+            return "[Race] " + user;
+        }
+
+        public static bool IsRaceComparison(string comparison)
+        {
+            return comparison.StartsWith("[Race] ");
+        }
+    }
+}

--- a/View/ChannelForm.cs
+++ b/View/ChannelForm.cs
@@ -123,6 +123,7 @@ namespace LiveSplit.Racetime.View
                     return;
                 }
             }
+            Channel.RemoveRaceComparisons();
             Channel.Authorized -= Channel_Authorized;
             Channel.RaceChanged -= Channel_RaceChanged;
             Channel.Disconnect();


### PR DESCRIPTION
Requires https://github.com/racetimeGG/racetime-app/pull/172 to be merged before working.

Adds support for creating and updating real time race comparisons for racetime.gg. A lot of the implementation for this copies the SRL implementation.