### PR TITLE
check if the image returned by the racetime.gg API is null before attempting to process it

### DIFF
--- a/RacetimeAPI.cs
+++ b/RacetimeAPI.cs
@@ -125,7 +125,7 @@ namespace LiveSplit.Racetime
                         {
                             return CategoryImagesCache[id];
                         }
-                        else
+                        else if (race.Data.category.image != null)
                         {
                             WebClient wc = new WebClient();
                             byte[] bytes = wc.DownloadData(race.Data.category.image);


### PR DESCRIPTION
I, and other users, running LiveSplit via wine continually run into an issue where LiveSplit freezes on startup if a) the racetime.gg plugin is enabled, and b) a race is running on racetime.gg that does not have an image associated with the game.

I've been unable to figure out what exactly is going wrong with wine that causes the freeze, but I do know that I've bothered setting up a dev environment to test this fix that this does successfully keep LiveSplit running under the circumstances, and would therefore like to get this fix applied upstream.